### PR TITLE
Remove recurse when creating the base OMERO directory

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,6 @@
   become: true
   file:
     path: "{{ omero_common_basedir }}"
-    recurse: true
     state: directory
     mode: 0755
 


### PR DESCRIPTION
To address the [Ansible E208 lint error](https://ansible-lint.readthedocs.io/en/latest/default_rules.html#risky-file-permissions), a default permission has been added to the directory creation task of this role. However, the combination of `mode` and `recurse` causes idempotence tests to fail. This does not happen in this repository per se but any downstream role (`ome.omero_server`, `ome.omero_web`) or playbook (see e.g. https://github.com/ome/ansible-example-omero-onenode/runs/1857468587?check_suite_focus=true) will fail.

This PR proposes to remove `recurse: true` which means the role will only set the permissions for the directory. Every downstream role should be responsible for managing its content permissions which feels like the correct behavior. Additionally, when running the playbook against already deployed OMERO servers or web deployments, I have noticed that this task can take tens of seconds depending on the number of objects so it also improves the overall performance.

The alternative option would be to revert the `mode` field but I could not identify the rational for `recurse: true` from the code/history so I suppose it might have been here for historical reasons.

Proposed tag: `0.3.4`